### PR TITLE
Fix protobuf version conflict caused by wandb installation

### DIFF
--- a/llama/requirements.txt
+++ b/llama/requirements.txt
@@ -6,6 +6,7 @@ transformers>=4.28.1
 torch
 sentencepiece
 tokenizers>=0.13.3
+protobuf==3.20.0
 wandb
 accelerate
 datasets


### PR DESCRIPTION
This pull request resolves a protobuf version conflict in the wandb package. The default wandb installation can cause a ```TypeError: Descriptors cannot not be created directly```, indicating an incompatible protobuf version. To address this, protobuf is manually downgraded to 3.20.0.